### PR TITLE
Change user cookie SameSite to none

### DIFF
--- a/server/src/cookies/index.ts
+++ b/server/src/cookies/index.ts
@@ -9,6 +9,7 @@ export const setUserCookie = (content: UserCookieContent | null, res: any) => {
   const options = {
     httpOnly: true,
     secure: true,
+    samesite: 'none',
     path: "/",
   };
 


### PR DESCRIPTION
This should partially solve #112, but it is not a full solution. If the user has blocked third-party cookies in his browser, it will not work.

We need some mechanism to detect if a user is authenticated, but there was no data from the cookie. In this situation, it should automatically re-fetch the data (using Auth Header - no page refresh). This would also fix the situation when the user is authenticated, but the cookie expired.