### PR TITLE
Refresh content when auth state updates

### DIFF
--- a/ui/src/components/comments/list/item/vote/CommentVote.tsx
+++ b/ui/src/components/comments/list/item/vote/CommentVote.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { CommentVotes } from "../../../CommentModel";
 import classNames from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -17,6 +17,12 @@ export const CommentVote: React.VFC<CommentVoteProps> = (props) => {
   const [sum, setSum] = useState(props.votes.sum);
   const [votedUp, setVotedUp] = useState(props.votes.votedUp);
   const [votedDown, setVotedDown] = useState(props.votes.votedDown);
+
+  useEffect(() => {
+    setSum(props.votes.sum);
+    setVotedUp(props.votes.votedUp);
+    setVotedDown(props.votes.votedDown);
+  }, [props.votes]);
 
   const wrapperClasses = classNames("flex flex-row items-center", {
     "space-x-2": props.enabled,

--- a/website/src/modules/comments/hooks/useComments.ts
+++ b/website/src/modules/comments/hooks/useComments.ts
@@ -27,7 +27,7 @@ export const useComments = (
   serverSideUid: string | null
 ): UseComments => {
   const [comments, setComments] = useState(initialState);
-  const { profile } = useSession();
+  const { profile, isLoading } = useSession();
   const prevUid = useRef(serverSideUid);
 
   const fetchComments = async (noCache: boolean) => {
@@ -53,12 +53,12 @@ export const useComments = (
   };
 
   useEffect(() => {
-    if (!profile) return;
+    if (isLoading) return;
 
-    if (profile.uid != prevUid.current) fetchComments(true);
+    if (profile?.uid != prevUid.current) fetchComments(true);
 
     prevUid.current = profile?.uid;
-  }, [profile?.uid]);
+  }, [profile?.uid, isLoading]);
 
   return {
     comments: comments,

--- a/website/src/modules/comments/hooks/useComments.ts
+++ b/website/src/modules/comments/hooks/useComments.ts
@@ -24,11 +24,11 @@ type UseComments = {
 export const useComments = (
   initialState: Array<CommentModel>,
   website: string,
-  serverSideAuthenticated: boolean
+  serverSideUid: string | null
 ): UseComments => {
   const [comments, setComments] = useState(initialState);
   const { profile } = useSession();
-  const prevProfileUid = useRef(profile?.uid);
+  const prevUid = useRef(serverSideUid);
 
   const fetchComments = async (noCache: boolean) => {
     const result = await getComments(website, noCache);
@@ -53,13 +53,9 @@ export const useComments = (
   };
 
   useEffect(() => {
-    if (!!profile && !prevProfileUid.current && serverSideAuthenticated) {
-      prevProfileUid.current = profile.uid;
-      return;
-    }
+    if (profile?.uid != prevUid.current) fetchComments(true);
 
-    fetchComments(true);
-    prevProfileUid.current = profile?.uid;
+    prevUid.current = profile?.uid;
   }, [profile?.uid]);
 
   return {

--- a/website/src/modules/comments/hooks/useComments.ts
+++ b/website/src/modules/comments/hooks/useComments.ts
@@ -53,7 +53,9 @@ export const useComments = (
   };
 
   useEffect(() => {
-    if (profile?.uid != prevUid.current) fetchComments(true);
+    if (!profile) return;
+
+    if (profile.uid != prevUid.current) fetchComments(true);
 
     prevUid.current = profile?.uid;
   }, [profile?.uid]);

--- a/website/src/modules/comments/hooks/useComments.ts
+++ b/website/src/modules/comments/hooks/useComments.ts
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import {
   CommentModel,
+  getComments,
   createComment,
   addCommentVoteDown,
   removeCommentVote,
-  addCommentVoteUp
+  addCommentVoteUp,
+  useSession
 } from '@disclave/client';
 
 type AddComment = (text: string) => Promise<void>;
@@ -19,8 +21,19 @@ type UseComments = {
   removeVote: RemoveVote;
 };
 
-export const useComments = (initialState: Array<CommentModel>, website: string): UseComments => {
+export const useComments = (
+  initialState: Array<CommentModel>,
+  website: string,
+  serverSideAuthenticated: boolean
+): UseComments => {
   const [comments, setComments] = useState(initialState);
+  const { profile } = useSession();
+  const prevProfileUid = useRef(profile?.uid);
+
+  const fetchComments = async (noCache: boolean) => {
+    const result = await getComments(website, noCache);
+    setComments(result);
+  };
 
   const addComment: AddComment = async (text: string) => {
     const addedComment = await createComment(text, website);
@@ -38,6 +51,16 @@ export const useComments = (initialState: Array<CommentModel>, website: string):
   const removeVote = async (commentId: string) => {
     await removeCommentVote(commentId);
   };
+
+  useEffect(() => {
+    if (!!profile && !prevProfileUid.current && serverSideAuthenticated) {
+      prevProfileUid.current = profile.uid;
+      return;
+    }
+
+    fetchComments(true);
+    prevProfileUid.current = profile?.uid;
+  }, [profile?.uid]);
 
   return {
     comments: comments,

--- a/website/src/modules/pages/website/WebsitePage.tsx
+++ b/website/src/modules/pages/website/WebsitePage.tsx
@@ -10,9 +10,14 @@ import { registerHref } from '@/pages/auth/register';
 export interface WebsitePageProps {
   website: string;
   comments: Array<CommentModel>;
+  serverSideAuthenticated: boolean;
 }
 
-export const WebsitePage: React.VFC<WebsitePageProps> = ({ website, comments }) => {
+export const WebsitePage: React.VFC<WebsitePageProps> = ({
+  website,
+  comments,
+  serverSideAuthenticated
+}) => {
   const loginHrefWithRedirect = loginHref(websiteHrefRaw, website);
   const registerHrefWithRedirect = registerHref(websiteHrefRaw, website);
 
@@ -25,6 +30,7 @@ export const WebsitePage: React.VFC<WebsitePageProps> = ({ website, comments }) 
           comments={comments}
           loginHref={loginHrefWithRedirect}
           registerHref={registerHrefWithRedirect}
+          serverSideAuthenticated={serverSideAuthenticated}
         />
       </div>
     </Layout>

--- a/website/src/modules/pages/website/WebsitePage.tsx
+++ b/website/src/modules/pages/website/WebsitePage.tsx
@@ -10,14 +10,10 @@ import { registerHref } from '@/pages/auth/register';
 export interface WebsitePageProps {
   website: string;
   comments: Array<CommentModel>;
-  serverSideAuthenticated: boolean;
+  serverSideUid: string | null;
 }
 
-export const WebsitePage: React.VFC<WebsitePageProps> = ({
-  website,
-  comments,
-  serverSideAuthenticated
-}) => {
+export const WebsitePage: React.VFC<WebsitePageProps> = ({ website, comments, serverSideUid }) => {
   const loginHrefWithRedirect = loginHref(websiteHrefRaw, website);
   const registerHrefWithRedirect = registerHref(websiteHrefRaw, website);
 
@@ -30,7 +26,7 @@ export const WebsitePage: React.VFC<WebsitePageProps> = ({
           comments={comments}
           loginHref={loginHrefWithRedirect}
           registerHref={registerHrefWithRedirect}
-          serverSideAuthenticated={serverSideAuthenticated}
+          serverSideUid={serverSideUid}
         />
       </div>
     </Layout>

--- a/website/src/modules/pages/website/comments/WebsiteComments.tsx
+++ b/website/src/modules/pages/website/comments/WebsiteComments.tsx
@@ -8,6 +8,7 @@ export interface WebsiteCommentsProps {
   comments: Array<CommentModel>;
   loginHref: string;
   registerHref: string;
+  serverSideAuthenticated: boolean;
 }
 
 export const WebsiteComments: React.VFC<WebsiteCommentsProps> = (props) => {
@@ -16,7 +17,8 @@ export const WebsiteComments: React.VFC<WebsiteCommentsProps> = (props) => {
   const website = props.website;
   const { comments, addComment, addVoteUp, addVoteDown, removeVote } = useComments(
     props.comments,
-    website
+    website,
+    props.serverSideAuthenticated
   );
 
   return (

--- a/website/src/modules/pages/website/comments/WebsiteComments.tsx
+++ b/website/src/modules/pages/website/comments/WebsiteComments.tsx
@@ -8,7 +8,7 @@ export interface WebsiteCommentsProps {
   comments: Array<CommentModel>;
   loginHref: string;
   registerHref: string;
-  serverSideAuthenticated: boolean;
+  serverSideUid: string | null;
 }
 
 export const WebsiteComments: React.VFC<WebsiteCommentsProps> = (props) => {
@@ -18,7 +18,7 @@ export const WebsiteComments: React.VFC<WebsiteCommentsProps> = (props) => {
   const { comments, addComment, addVoteUp, addVoteDown, removeVote } = useComments(
     props.comments,
     website,
-    props.serverSideAuthenticated
+    props.serverSideUid
   );
 
   return (

--- a/website/src/pages/website/[website]/iframe.tsx
+++ b/website/src/pages/website/[website]/iframe.tsx
@@ -24,14 +24,14 @@ export const getServerSideProps: GetServerSideProps<IFrameProps> = async (contex
   return {
     props: {
       comments,
-      serverSideAuthenticated: !!userCookie
+      serverSideUid: userCookie?.uid
     }
   };
 };
 
 interface IFrameProps {
   comments: Array<CommentModel>;
-  serverSideAuthenticated: boolean;
+  serverSideUid: string | null;
 }
 
 const Index: React.FC<IFrameProps> = (props) => {
@@ -46,7 +46,7 @@ const Index: React.FC<IFrameProps> = (props) => {
   const { comments, addComment, addVoteUp, addVoteDown, removeVote } = useComments(
     props.comments,
     website,
-    props.serverSideAuthenticated
+    props.serverSideUid
   );
 
   const loginHrefWithRedirect = loginHref();

--- a/website/src/pages/website/[website]/iframe.tsx
+++ b/website/src/pages/website/[website]/iframe.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps: GetServerSideProps<IFrameProps> = async (contex
   return {
     props: {
       comments,
-      serverSideUid: userCookie?.uid
+      serverSideUid: userCookie?.uid || null,
     }
   };
 };

--- a/website/src/pages/website/[website]/iframe.tsx
+++ b/website/src/pages/website/[website]/iframe.tsx
@@ -12,7 +12,7 @@ import { useContainerHeightMessage } from '@/modules/iframe';
 
 export const websiteIframeHref = (url: string) => `/website/${url}/iframe/`;
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps<IFrameProps> = async (context) => {
   await initServer();
   const { website } = context.query;
 
@@ -23,16 +23,18 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   return {
     props: {
-      comments
+      comments,
+      serverSideAuthenticated: !!userCookie
     }
   };
 };
 
-interface WebsiteProps {
+interface IFrameProps {
   comments: Array<CommentModel>;
+  serverSideAuthenticated: boolean;
 }
 
-const Index: React.FC<WebsiteProps> = (props) => {
+const Index: React.FC<IFrameProps> = (props) => {
   const containerRef = useRef<HTMLDivElement>();
   useContainerHeightMessage(containerRef);
 
@@ -43,7 +45,8 @@ const Index: React.FC<WebsiteProps> = (props) => {
 
   const { comments, addComment, addVoteUp, addVoteDown, removeVote } = useComments(
     props.comments,
-    website
+    website,
+    props.serverSideAuthenticated
   );
 
   const loginHrefWithRedirect = loginHref();

--- a/website/src/pages/website/[website]/index.tsx
+++ b/website/src/pages/website/[website]/index.tsx
@@ -23,7 +23,7 @@ export const getServerSideProps: GetServerSideProps<WebsiteProps> = async (conte
   return {
     props: {
       comments: await commentsPromise,
-      serverSideAuthenticated: !!userCookie,
+      serverSideUid: userCookie?.uid,
       ...(await translationsPromise)
     }
   };
@@ -31,7 +31,7 @@ export const getServerSideProps: GetServerSideProps<WebsiteProps> = async (conte
 
 interface WebsiteProps {
   comments: Array<CommentModel>;
-  serverSideAuthenticated: boolean;
+  serverSideUid: string | null;
 }
 
 const Website: React.FC<WebsiteProps> = (props) => {
@@ -39,11 +39,7 @@ const Website: React.FC<WebsiteProps> = (props) => {
   const website = router.query.website as string;
 
   return (
-    <WebsitePage
-      website={website}
-      comments={props.comments}
-      serverSideAuthenticated={props.serverSideAuthenticated}
-    />
+    <WebsitePage website={website} comments={props.comments} serverSideUid={props.serverSideUid} />
   );
 };
 export default Website;

--- a/website/src/pages/website/[website]/index.tsx
+++ b/website/src/pages/website/[website]/index.tsx
@@ -10,7 +10,7 @@ import { initServer } from '@/modules/server';
 export const websiteHref = (url: string) => websiteHrefRaw + encodeUrl(url);
 export const websiteHrefRaw = '/website/';
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps<WebsiteProps> = async (context) => {
   await initServer();
   const { website } = context.query;
 
@@ -23,6 +23,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return {
     props: {
       comments: await commentsPromise,
+      serverSideAuthenticated: !!userCookie,
       ...(await translationsPromise)
     }
   };
@@ -30,12 +31,19 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
 interface WebsiteProps {
   comments: Array<CommentModel>;
+  serverSideAuthenticated: boolean;
 }
 
 const Website: React.FC<WebsiteProps> = (props) => {
   const router = useRouter();
   const website = router.query.website as string;
 
-  return <WebsitePage website={website} comments={props.comments} />;
+  return (
+    <WebsitePage
+      website={website}
+      comments={props.comments}
+      serverSideAuthenticated={props.serverSideAuthenticated}
+    />
+  );
 };
 export default Website;

--- a/website/src/pages/website/[website]/index.tsx
+++ b/website/src/pages/website/[website]/index.tsx
@@ -23,7 +23,7 @@ export const getServerSideProps: GetServerSideProps<WebsiteProps> = async (conte
   return {
     props: {
       comments: await commentsPromise,
-      serverSideUid: userCookie?.uid,
+      serverSideUid: userCookie?.uid || null,
       ...(await translationsPromise)
     }
   };


### PR DESCRIPTION
Now it should also work when the user blocks all third-party cookies in the browser. In that case, it will re-fetch comments data after the user authenticates on the client-side.

fix #112 