### PR TITLE
Add top rated pages and blog to menu

### DIFF
--- a/website/public/locales/en/layout.json
+++ b/website/public/locales/en/layout.json
@@ -26,8 +26,10 @@
       "plugins": "Plugins",
       "extensions": "Extensions",
       "mobile": "Mobile",
+      "blog": "Blog",
       "top comments": "Top comments",
       "top commented pages": "Top commented pages",
+      "top rated pages": "Top rated pages",
       "latest comments": "Latest comments"
     },
     "contact": {

--- a/website/public/locales/en/layout.json
+++ b/website/public/locales/en/layout.json
@@ -6,9 +6,22 @@
   "header": {
     "main nav": {
       "home": "Home",
-      "top comments": "Top comments",
+      "comments": {
+        "label": "Comments",
+        "items": {
+          "top": "Top comments",
+          "latest": "Latest comments"
+        }
+      },
+      "pages": {
+        "label": "Pages",
+        "items": {
+          "top commented": "Top commented",
+          "top rated": "Top rated"
+        }
+      },
       "top commented pages": "Top commented pages",
-      "latest comments": "Latest comments",
+      "blog": "Blog",
       "plugins": "Plugins",
       "extensions": "Extensions",
       "mobile": "Mobile"

--- a/website/src/modules/blog/blog.ts
+++ b/website/src/modules/blog/blog.ts
@@ -26,7 +26,7 @@ export const getPost = async (id: string): Promise<Post> => {
   const contentHtml = await markdownToHtml(rawPost.content);
 
   const contentText = contentHtml.replace(/<[^>]*>?/gm, '');
-  const seoDescription = `${contentText.substr(0, 130)}...`;
+  const seoDescription = `${contentText.substr(0, 160)}...`;
 
   return {
     id,

--- a/website/src/modules/layout/_footer/nav/Nav.tsx
+++ b/website/src/modules/layout/_footer/nav/Nav.tsx
@@ -8,16 +8,19 @@ import { pluginsHref } from '@/pages/plugins';
 import { extensionsHref } from '@/pages/extensions';
 import { topCommentedPagesHref } from '@/pages/pages/top-commented';
 import { mobileHref } from '@/pages/mobile';
+import { blogHref } from '@/pages/blog';
+import { topRatedPagesHref } from '@/pages/pages/top-rated';
 
 export const Nav: React.VFC = () => {
   const { t } = useTranslation('layout');
 
   return (
     <nav>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
+      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-4 gap-2">
         <div>
           <ul className="space-y-2 fa-ul ml-5">
             <NavItem href={homeHref()} text={t('footer.nav.home')} />
+            <NavItem href={blogHref()} text={t('footer.nav.blog')} />
             <NavItem href={pluginsHref()} text={t('footer.nav.plugins')} />
             <NavItem href={extensionsHref()} text={t('footer.nav.extensions')} />
             <NavItem href={mobileHref()} text={t('footer.nav.mobile')} />
@@ -25,9 +28,10 @@ export const Nav: React.VFC = () => {
         </div>
         <div>
           <ul className="space-y-2 fa-ul ml-5">
-            <NavItem href={topCommentsHref()} text={t('header.main nav.top comments')} />
-            <NavItem href={topCommentedPagesHref()} text={t('header.main nav.top commented pages')} />
-            <NavItem href={latestCommentsHref()} text={t('header.main nav.latest comments')} />
+            <NavItem href={topCommentsHref()} text={t('footer.nav.top comments')} />
+            <NavItem href={topCommentedPagesHref()} text={t('footer.nav.top commented pages')} />
+            <NavItem href={topRatedPagesHref()} text={t('footer.nav.top rated pages')} />
+            <NavItem href={latestCommentsHref()} text={t('footer.nav.latest comments')} />
           </ul>
         </div>
       </div>

--- a/website/src/modules/layout/_header/Header.tsx
+++ b/website/src/modules/layout/_header/Header.tsx
@@ -15,21 +15,21 @@ export const Header: React.VFC<HeaderProps> = (props) => {
 
   const headerClasses = classNames(
     'h-12 md:h-20 box-content',
-    'py-1 lg:mx-12',
-    'flex items-center flex-wrap md:flex-nowrap'
+    'py-1 md:mx-12',
+    'flex items-center flex-wrap lg:flex-nowrap'
   );
 
   return (
     <div className="sticky top-0 bg-white shadow z-50">
       <header className={headerClasses}>
-        <Logo className="ml-3 md:ml-0" />
+        <Logo className="ml-3 lg:ml-0" />
         <HeaderAuth
-          className="md:order-2 flex-grow md:flex-grow-0 mx-2 justify-items-end"
+          className="lg:order-2 flex-grow lg:flex-grow-0 mx-2 justify-items-end"
           loginHref={props.loginHref}
           registerHref={props.registerHref}
         />
-        <NavBtn navExtended={navExtended} onClick={toggleNav} className="md:hidden" />
-        <div className="flex-full md:flex-1 md:mx-4 bg-white">
+        <NavBtn navExtended={navExtended} onClick={toggleNav} className="lg:hidden" />
+        <div className="flex-full lg:flex-1 lg:mx-4 bg-white">
           <NavBar toggleState={navExtended} />
         </div>
       </header>

--- a/website/src/modules/layout/_header/navigation/NavBar.tsx
+++ b/website/src/modules/layout/_header/navigation/NavBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavItem } from './item';
+import { NavItem, SubMenu } from './item';
 import { useTranslation } from 'next-i18next';
 import classNames from 'classnames';
 import { homeHref } from '@/pages';
@@ -9,6 +9,8 @@ import { pluginsHref } from '@/pages/plugins';
 import { extensionsHref } from '@/pages/extensions';
 import { topCommentedPagesHref } from '@/pages/pages/top-commented';
 import { mobileHref } from '@/pages/mobile';
+import { topRatedPagesHref } from '@/pages/pages/top-rated';
+import { blogHref } from '@/pages/blog';
 
 export interface NavBarProps {
   toggleState: boolean;
@@ -17,22 +19,31 @@ export interface NavBarProps {
 export const NavBar: React.VFC<NavBarProps> = ({ toggleState }) => {
   const { t } = useTranslation('layout');
 
-  const navClasses = classNames('flex flex-col md:flex-row md:justify-end', {
+  const navClasses = classNames('flex flex-col lg:flex-row lg:justify-end', {
     'p-2 shadow': toggleState
   });
 
   const ulClasses = classNames(
-    toggleState ? 'flex' : 'hidden md:flex',
-    'flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-4 md:items-center'
+    toggleState ? 'flex' : 'hidden lg:flex',
+    'flex-col lg:flex-row space-y-4 lg:space-y-0 lg:space-x-4 lg:items-center'
   );
 
   return (
     <nav className={navClasses}>
       <ul className={ulClasses}>
         <NavItem href={homeHref()} text={t('header.main nav.home')} />
-        <NavItem href={topCommentsHref()} text={t('header.main nav.top comments')} />
-        <NavItem href={topCommentedPagesHref()} text={t('header.main nav.top commented pages')} />
-        <NavItem href={latestCommentsHref()} text={t('header.main nav.latest comments')} />
+        <SubMenu text={t('header.main nav.comments.label')}>
+          <NavItem href={topCommentsHref()} text={t('header.main nav.comments.items.top')} />
+          <NavItem href={latestCommentsHref()} text={t('header.main nav.comments.items.latest')} />
+        </SubMenu>
+        <SubMenu text={t('header.main nav.pages.label')}>
+          <NavItem
+            href={topCommentedPagesHref()}
+            text={t('header.main nav.pages.items.top commented')}
+          />
+          <NavItem href={topRatedPagesHref()} text={t('header.main nav.pages.items.top rated')} />
+        </SubMenu>
+        <NavItem href={blogHref()} text={t('header.main nav.blog')} />
         <NavItem href={pluginsHref()} text={t('header.main nav.plugins')} />
         <NavItem href={extensionsHref()} text={t('header.main nav.extensions')} />
         <NavItem href={mobileHref()} text={t('header.main nav.mobile')} />

--- a/website/src/modules/layout/_header/navigation/item/SubMenu.tsx
+++ b/website/src/modules/layout/_header/navigation/item/SubMenu.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
+
+export interface SubMenuProps {
+  text: string;
+}
+
+export const SubMenu: React.FC<SubMenuProps> = ({ children, text }) => {
+  const [navExtended, setNavExtended] = useState(false);
+  const toggleNav = () => setNavExtended(!navExtended);
+
+  const wrapperClasses = classNames('group relative');
+  const linkClasses = classNames('cursor-default group-hover:text-primary group-hover:underline');
+  const contentClasses = classNames(
+    'lg:absolute pt-2',
+    navExtended ? 'visible opacity-100 block' : 'invisible opacity-0 hidden',
+    'lg:invisible lg:opacity-0 lg:group-hover:visible lg:group-hover:opacity-100',
+    'lg:block',
+    'transition-all duration-300'
+  );
+  const ulClasses = classNames(
+    'lg:bg-white lg:rounded-b lg:shadow px-4 lg:py-4 w-max flex flex-col space-y-4'
+  );
+
+  const onClick: React.MouseEventHandler<HTMLLIElement> = (e) => {
+    toggleNav();
+  };
+
+  return (
+    <li className={wrapperClasses} onClick={onClick}>
+      <div className={linkClasses}>
+        {text}
+        <FontAwesomeIcon icon={faAngleDown} className="ml-2 text-sm" />
+      </div>
+      <div className={contentClasses}>
+        <ul className={ulClasses}>{children}</ul>
+      </div>
+    </li>
+  );
+};

--- a/website/src/modules/layout/_header/navigation/item/index.ts
+++ b/website/src/modules/layout/_header/navigation/item/index.ts
@@ -1,1 +1,2 @@
 export { NavItem } from './NavItem';
+export { SubMenu } from './SubMenu';

--- a/website/src/pages/pages/top-rated.tsx
+++ b/website/src/pages/pages/top-rated.tsx
@@ -6,7 +6,7 @@ import { PageModel } from '@disclave/client';
 import React from 'react';
 import { TopRatedPages } from '@/modules/layout/pages/top-rated';
 
-export const topCommentedPagesHref = () => '/pages/top-rated';
+export const topRatedPagesHref = () => '/pages/top-rated';
 
 export const getServerSideProps: GetServerSideProps<TopRatedProps> = async (context) => {
   await initServer();

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -19,7 +19,10 @@ module.exports = {
     }
   },
   variants: {
-    extend: {}
+    extend: {
+      display: ['group-hover'],
+      visibility: ['group-hover']
+    }
   },
   plugins: []
 };


### PR DESCRIPTION
1. Top navigation update - nested items supported.
2. Top-rated page ranking and blog added to the navigation (header and footer).
3. Top-rated page ranking query fixed - include pages without comments
4. SEO fix - description length update to 160 characters

#168 
#159 